### PR TITLE
Moved check for command line arguments.

### DIFF
--- a/examples/benchmarks/stencil/edat/stencil_basic.c
+++ b/examples/benchmarks/stencil/edat/stencil_basic.c
@@ -28,7 +28,7 @@
 #define WEIGHT(ii,jj) weight[ii+RADIUS][jj+RADIUS]
 
 static void displayPreamble(int, int, int, int, int, int);
-static void errorCheckParameters(int, int, int, long, int, int, int);
+static void errorCheckParameters(int, int, long, int, int, int);
 static void initialise_in_out_arrays(DTYPE ** RESTRICT, DTYPE ** RESTRICT, int, int, int, int, int, int, int);
 static void initialise_stencil_weights(DTYPE [2*RADIUS+1][2*RADIUS+1]);
 static void allocate_comms_buffers(DTYPE**, DTYPE**, DTYPE**, DTYPE**, int, int, int);
@@ -66,11 +66,16 @@ int main(int argc, char ** argv) {
   ** process, test, and broadcast input parameters
   ********************************************************************************/
 
+  if (argc != 3){
+    if (my_ID == ROOT_PROCESS) fprintf(stderr, "Usage: stencil <# iterations> <array dimension> \n");
+    exit(EXIT_FAILURE);
+  }
+
   iterations = atoi(*++argv);
   n = atoi(*++argv);
   nsquare = (long) n * (long) n;
 
-  errorCheckParameters(my_ID, argc, iterations, nsquare, Num_procs, RADIUS, n);
+  errorCheckParameters(my_ID, iterations, nsquare, Num_procs, RADIUS, n);
 
   /* determine best way to create a 2D grid of ranks (closest to square)     */
   factor(Num_procs, &Num_procsx, &Num_procsy);
@@ -435,7 +440,7 @@ static void allocate_comms_buffers(DTYPE **comm_buffer_up, DTYPE **comm_buffer_d
   }
 }
 
-static void errorCheckParameters(int my_ID, int argc, int iterations, long nsquare, int num_procs, int radius, int n) {
+static void errorCheckParameters(int my_ID, int iterations, long nsquare, int num_procs, int radius, int n) {
   if (my_ID == ROOT_PROCESS) {
     printf("Parallel Research Kernels version %s\n", PRKVERSION);
     printf("EDAT stencil execution on 2D grid\n");
@@ -444,11 +449,6 @@ static void errorCheckParameters(int my_ID, int argc, int iterations, long nsqua
   if (my_ID == ROOT_PROCESS) fprintf(stderr, "ERROR: Compact stencil not supported\n");
   exit(EXIT_FAILURE);
 #endif
-  if (argc != 3){
-    if (my_ID == ROOT_PROCESS) fprintf(stderr, "Usage: stencil <# iterations> <array dimension> \n");
-    exit(EXIT_FAILURE);
-  }
-
   if (iterations < 1){
     if (my_ID == ROOT_PROCESS) fprintf(stderr, "ERROR: iterations must be >= 1 : %d \n", iterations);
     exit(EXIT_FAILURE);

--- a/examples/benchmarks/stencil/edat/stencil_context.c
+++ b/examples/benchmarks/stencil/edat/stencil_context.c
@@ -37,7 +37,7 @@ struct mycontext {
 };
 
 static void displayPreamble(int, int, int, int, int, int);
-static void errorCheckParameters(int, int, int, long, int, int, int);
+static void errorCheckParameters(int, int, long, int, int, int);
 static void initialise_in_out_arrays(struct mycontext *, int);
 static void initialise_stencil_weights(struct mycontext *);
 static void allocate_comms_buffers(DTYPE**, DTYPE**, DTYPE**, DTYPE**, int, int, int);
@@ -75,11 +75,16 @@ int main(int argc, char ** argv) {
   ** process, test, and broadcast input parameters
   ********************************************************************************/
 
+  if (argc != 3){
+    if (my_ID == ROOT_PROCESS) fprintf(stderr, "Usage: stencil <# iterations> <array dimension> \n");
+    exit(EXIT_FAILURE);
+  }
+
   context->iterations = atoi(*++argv);
   context->n = atoi(*++argv);
   context->nsquare = (long) context->n * (long) context->n;
 
-  errorCheckParameters(my_ID, argc, context->iterations, context->nsquare, Num_procs, RADIUS, context->n);
+  errorCheckParameters(my_ID, context->iterations, context->nsquare, Num_procs, RADIUS, context->n);
 
   /* determine best way to create a 2D grid of ranks (closest to square)     */
   factor(Num_procs, &(context->Num_procsx), &(context->Num_procsy));
@@ -457,7 +462,7 @@ static void allocate_comms_buffers(DTYPE **comm_buffer_up, DTYPE **comm_buffer_d
   }
 }
 
-static void errorCheckParameters(int my_ID, int argc, int iterations, long nsquare, int num_procs, int radius, int n) {
+static void errorCheckParameters(int my_ID, int iterations, long nsquare, int num_procs, int radius, int n) {
   if (my_ID == ROOT_PROCESS) {
     printf("Parallel Research Kernels version %s\n", PRKVERSION);
     printf("EDAT stencil execution on 2D grid\n");
@@ -466,11 +471,6 @@ static void errorCheckParameters(int my_ID, int argc, int iterations, long nsqua
   if (my_ID == ROOT_PROCESS) fprintf(stderr, "ERROR: Compact stencil not supported\n");
   exit(EXIT_FAILURE);
 #endif
-  if (argc != 3){
-    if (my_ID == ROOT_PROCESS) fprintf(stderr, "Usage: stencil <# iterations> <array dimension> \n");
-    exit(EXIT_FAILURE);
-  }
-
   if (iterations < 1){
     if (my_ID == ROOT_PROCESS) fprintf(stderr, "ERROR: iterations must be >= 1 : %d \n", iterations);
     exit(EXIT_FAILURE);

--- a/examples/benchmarks/stencil/mpi/stencil.c
+++ b/examples/benchmarks/stencil/mpi/stencil.c
@@ -28,7 +28,7 @@
 #define WEIGHT(ii,jj) weight[ii+RADIUS][jj+RADIUS]
 
 static void displayPreamble(int, int, int, int, int, int);
-static void errorCheckParameters(int, int, int, long, int, int, int);
+static void errorCheckParameters(int, int, long, int, int, int);
 static void initialise_in_out_arrays(DTYPE ** RESTRICT, DTYPE ** RESTRICT, int, int, int, int, int, int, int);
 static void initialise_stencil_weights(DTYPE [2*RADIUS+1][2*RADIUS+1]);
 static void allocate_comms_buffers(DTYPE**, DTYPE**, DTYPE**, DTYPE**, DTYPE**, DTYPE**, DTYPE**, DTYPE**, int, int, int);
@@ -78,11 +78,16 @@ int main(int argc, char ** argv) {
   ** process, test, and broadcast input parameters
   ********************************************************************************/
 
+  if (argc != 3){
+    if (my_ID == ROOT_PROCESS) fprintf(stderr, "Usage: stencil <# iterations> <array dimension> \n");
+    exit(EXIT_FAILURE);
+  }
+
   iterations = atoi(*++argv);
   n = atoi(*++argv);
   nsquare = (long) n * (long) n;
 
-  errorCheckParameters(my_ID, argc, iterations, nsquare, Num_procs, RADIUS, n);
+  errorCheckParameters(my_ID, iterations, nsquare, Num_procs, RADIUS, n);
 
   /* determine best way to create a 2D grid of ranks (closest to square)     */
   factor(Num_procs, &Num_procsx, &Num_procsy);
@@ -341,7 +346,7 @@ static void allocate_comms_buffers(DTYPE **top_buf_out, DTYPE **top_buf_in, DTYP
   *left_buf_in    = *right_buf_out + 3*RADIUS*height;
 }
 
-static void errorCheckParameters(int my_ID, int argc, int iterations, long nsquare, int num_procs, int radius, int n) {
+static void errorCheckParameters(int my_ID, int iterations, long nsquare, int num_procs, int radius, int n) {
   if (my_ID == ROOT_PROCESS) {
     printf("Parallel Research Kernels version %s\n", PRKVERSION);
     printf("MPI stencil execution on 2D grid\n");
@@ -350,11 +355,6 @@ static void errorCheckParameters(int my_ID, int argc, int iterations, long nsqua
   if (my_ID == ROOT_PROCESS) fprintf(stderr, "ERROR: Compact stencil not supported\n");
   exit(EXIT_FAILURE);
 #endif
-  if (argc != 3){
-    if (my_ID == ROOT_PROCESS) fprintf(stderr, "Usage: stencil <# iterations> <array dimension> \n");
-    exit(EXIT_FAILURE);
-  }
-
   if (iterations < 1){
     if (my_ID == ROOT_PROCESS) fprintf(stderr, "ERROR: iterations must be >= 1 : %d \n", iterations);
     exit(EXIT_FAILURE);


### PR DESCRIPTION
The number of provided arguments should be tested before trying to
access them and perform the validation of the input. This fixes #1.